### PR TITLE
Add asset issuance

### DIFF
--- a/bitcoin/client.go
+++ b/bitcoin/client.go
@@ -48,6 +48,10 @@ func New(ctx context.Context, options BitcoinOptions) *BitcoinClient {
 		Password:      options.Pass,
 	})
 
+	return NewWithClient(ctx, client)
+}
+
+func NewWithClient(ctx context.Context, client *rpc.Client) *BitcoinClient {
 	return &BitcoinClient{
 		client: client,
 	}

--- a/bitcoin/client.go
+++ b/bitcoin/client.go
@@ -243,6 +243,38 @@ func (p *BitcoinClient) listUnspent(ctx context.Context, minConf, maxConf int, f
 	return result, nil
 }
 
+func (p *BitcoinClient) ListIssuances(ctx context.Context, asset string) ([]common.IssuanceInfo, error) {
+	log := logger.Logger(ctx).WithField("Method", "bitcoin.listIssuances")
+	client := p.client
+	if p.client == nil {
+		return nil, ErrInternalError
+	}
+
+	list, err := commands.ListIssuances(ctx, client.Client, commands.AssetID(asset))
+	if err != nil {
+		log.WithError(err).
+			Error("ListIssuances failed")
+		return nil, ErrRPCError
+	}
+
+	var result []common.IssuanceInfo
+	for _, issuance := range list {
+		result = append(result, common.IssuanceInfo{
+			TxID:         issuance.TxID,
+			Entropy:      issuance.Entropy,
+			Asset:        issuance.Asset,
+			Token:        issuance.Token,
+			Vin:          issuance.Vin,
+			AssetAmount:  issuance.AssetAmount,
+			TokenAmount:  issuance.TokenAmount,
+			IsReissuance: issuance.IsReissuance,
+			AssetBlinds:  issuance.AssetBlinds,
+			TokenBlinds:  issuance.TokenBlinds,
+		})
+	}
+	return result, nil
+}
+
 func (p *BitcoinClient) LockUnspent(ctx context.Context, unlock bool, transactions ...common.TransactionInfo) error {
 	log := logger.Logger(ctx).WithField("Method", "bitcoin.LockUnspent")
 

--- a/bitcoin/cmd/cli/Readme.md
+++ b/bitcoin/cmd/cli/Readme.md
@@ -1,0 +1,41 @@
+# Bitcoin / Elements RPC wallet
+
+## Setup
+
+### Start bitcoin and elements regtest nodes
+
+### Make sure that you have some fund available
+
+### Configure environment variables
+
+1. Bitcoin
+`export BITCOIN_TESTNET_HOSTNAME="your_hostname"`  (Default `bitcoin_testnet`)
+`export BITCOIN_TESTNET_PORT=port_configured_in_bitcoin_conf`  (Default `18332`)
+`export BITCOIN_TESTNET_USER="rpc_user_in_conf"` (Default `bank-wallet`)
+`export BITCOIN_TESTNET_PASSWORD="rpc_password_in_conf"` (Default `password1`)
+
+2. Elements 
+`export ELEMENTS_TESTNET_HOSTNAME="your_hostname"`  (Default `elements_regtest`)
+`export ELEMENTS_TESTNET_PORT=port_configured_in_elements_conf`  (Default `28432`)
+`export ELEMENTS_TESTNET_USER="rpc_user_in_conf"` (Default `bank-wallet`)
+`export ELEMENTS_TESTNET_PASSWORD="rpc_password_in_conf"` (Default `password1`)
+
+## Test a simple Bitcoin transaction
+
+`go run wallet/bitcoin/cmd/cli/main.go -command=RawTransactionBitcoin`
+
+## Test a simple Elements transaction
+
+`go run wallet/bitcoin/cmd/cli/main.go -command=RawTransactionElements`
+
+## Test asset issuance
+
+`go run wallet/bitcoin/cmd/cli/main.go -command=AssetIssuance -dest=$DESTADDR -change=$CHANGEADDR -asset=$ASSETADDR -token=$TOKENADDR`
+
+## Test asset reissuance
+
+`go run wallet/bitcoin/cmd/cli/main.go -command=Reissuance -change=$CHANGEADDR -asset=$ASSETADDR -token=$TOKENADDR -reissue=$ASSET`
+
+## Test asset burn asset
+
+`go run wallet/bitcoin/cmd/cli/main.go -command=BurnAsset -burnAsset=$ASSET -burnAmount=$AMOUNT -dest=$DESTADDR -change=$CHANGEADDR`

--- a/bitcoin/cmd/cli/main.go
+++ b/bitcoin/cmd/cli/main.go
@@ -45,6 +45,8 @@ func main() {
 	var assetAddress string
 	var tokenAddress string
 	var reissuedAsset string
+	var burnAsset string
+	var amountBurn float64
 
 	flag.StringVar(&command, "command", "", "Sub command to start")
 
@@ -53,6 +55,8 @@ func main() {
 	flag.StringVar(&assetAddress, "asset", "", "Address to send asset")
 	flag.StringVar(&tokenAddress, "token", "", "Address to send token")
 	flag.StringVar(&reissuedAsset, "reissue", "", "Asset to reissue")
+	flag.StringVar(&burnAsset, "burnAsset", "", "Asset to burn")
+	flag.Float64Var(&amountBurn, "burnAmount", 0.0, "Amount of assets to burn")
 	flag.Parse()
 
 	ctx := context.Background()
@@ -128,6 +132,14 @@ func main() {
 
 	case "Reissuance":
 		err = Reissuance(ctx, changeAddress, assetAddress, tokenAddress, reissuedAsset)
+
+	case "BurnAsset":
+		err = BurnAsset(ctx,
+			destAddress,
+			changeAddress,
+			burnAsset,
+			amountBurn,
+		)
 
 	default:
 		log.Fatalf("Unknown command %s.", command)
@@ -377,6 +389,22 @@ func Reissuance(ctx context.Context, changeAddress, assetAddress, tokenAddress, 
 	}
 
 	log.Printf("Asset %s reissued in Tx %s", request.AssetID, reissued.TxID)
+
+	return nil
+}
+
+func BurnAsset(ctx context.Context, destAddress, changeAddress, asset string, amount float64) error {
+	request := common.BurnRequest{
+		Chain:    "liquid-regtest",
+		IssuerID: 42,
+		Asset:    asset,
+		Amount:   amount,
+	}
+	burned, err := chain.BurnAsset(ctx, destAddress, changeAddress, request)
+	if err != nil {
+		return err
+	}
+	log.Printf("%f of asset %s have been burnt in Tx %s", amount, asset, burned.TxID)
 
 	return nil
 }

--- a/bitcoin/cmd/cli/main.go
+++ b/bitcoin/cmd/cli/main.go
@@ -6,8 +6,11 @@ package main
 
 import (
 	"context"
+	"errors"
+	"flag"
 	"log"
 	"os"
+	"strconv"
 
 	"github.com/condensat/bank-wallet/common"
 	"github.com/condensat/bank-wallet/rpc"
@@ -21,48 +24,85 @@ func init() {
 	_ = dotenv.Load()
 }
 
-func main() {
-	ctx := context.Background()
-	RawTransaction(ctx)
+type ChainOption struct {
+	Chain    string
+	HostName string
+	Port     int
+	User     string
+	Pass     string
 }
 
-func RawTransaction(ctx context.Context) {
-	rpcClient := bitcoinRpcClient("bitcoin-testnet", 18332)
-	if rpcClient == nil {
-		panic("Invalid rpcClient")
+type ChainsOptions struct {
+	Chains []ChainOption
+}
+
+func main() {
+	var command string
+
+	flag.StringVar(&command, "command", "", "Sub command to start")
+
+	flag.Parse()
+
+	ctx := context.Background()
+
+	// add CryptoMode to context
+	ctx = common.CryptoModeContext(ctx, common.CryptoModeBitcoinCore)
+
+	var err error
+	switch command {
+
+	// Bitcoin Standard
+
+	case "RawTransactionBitcoin":
+		err = RawTransactionBitcoin(ctx)
+
+	default:
+		log.Fatalf("Unknown command %s.", command)
 	}
 
+	if err != nil {
+		log.Fatalf("Failed to process command. %v", err)
+	}
+}
+
+// Bitcoin Standard
+
+func RawTransactionBitcoin(ctx context.Context) error {
+	rpcClient := bitcoinRpcClient()
+
+	destAddress := "bcrt1qjlw9gfrqk0w2ljegl7vwzrt2rk7sst8d4hm7n9"
+
 	hex, err := commands.CreateRawTransaction(ctx, rpcClient, nil, []commands.SpendInfo{
-		{Address: "tb1qqjv0dec9vagycgwpchdkxsnapl9uy92dek4nau", Amount: 0.000003},
+		{Address: destAddress, Amount: 0.003},
 	}, nil)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	log.Printf("CreateRawTransaction: %s\n", hex)
 
 	rawTx, err := commands.DecodeRawTransaction(ctx, rpcClient, hex)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	decoded, err := commands.ConvertToRawTransactionBitcoin(rawTx)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	log.Printf("DecodeRawTransaction: %+v\n", decoded)
 
 	funded, err := commands.FundRawTransaction(ctx, rpcClient, hex)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	log.Printf("FundRawTransaction: %+v\n", funded)
 
 	rawTx, err = commands.DecodeRawTransaction(ctx, rpcClient, commands.Transaction(funded.Hex))
 	if err != nil {
-		panic(err)
+		return err
 	}
 	decoded, err = commands.ConvertToRawTransactionBitcoin(rawTx)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	log.Printf("FundRawTransaction Hex: %+v\n", decoded)
 
@@ -71,7 +111,7 @@ func RawTransaction(ctx context.Context) {
 
 		txInfo, err := commands.GetTransaction(ctx, rpcClient, in.Txid, true)
 		if err != nil {
-			panic(err)
+			return err
 		}
 
 		addressMap[txInfo.Address] = txInfo.Address
@@ -83,25 +123,61 @@ func RawTransaction(ctx context.Context) {
 
 	signed, err := commands.SignRawTransactionWithWallet(ctx, rpcClient, commands.Transaction(funded.Hex))
 	if err != nil {
-		panic(err)
+		return err
 	}
 	if !signed.Complete {
-		panic("SignRawTransactionWithWallet failed")
+		return errors.New("SignRawTransactionWithWallet failed")
 	}
-	log.Printf("SignRawTransactionWithWallet: %+v\n", signed.Hex)
+	log.Printf("Signed transaction is: %+v\n", signed.Hex)
 
-	txId, err := commands.SendRawTransaction(ctx, rpcClient, commands.Transaction(signed.Hex))
+	accepted, err := commands.TestMempoolAccept(ctx, rpcClient, signed.Hex)
 	if err != nil {
-		panic(err)
+		return err
 	}
-	log.Printf("SendRawTransaction: %+v\n", txId)
+
+	log.Printf("Accepted in the mempool: %+v\n", accepted.Allowed)
+	if !accepted.Allowed {
+		log.Printf("Reject-reason: %+v", accepted.Reason)
+		return errors.New("TestMempoolAccept failed")
+	}
+
+	return nil
 }
 
-func bitcoinRpcClient(hostname string, port int) commands.RpcClient {
+// Helpers
+
+func bitcoinRpcClient() commands.RpcClient {
+	hostname := os.Getenv("BITCOIN_TESTNET_HOSTNAME")
+	if len(hostname) == 0 {
+		hostname = "bitcoin_testnet"
+	}
+	port, _ := strconv.Atoi(os.Getenv("BITCOIN_TESTNET_PORT"))
+	if port == 0 {
+		port = 18332
+	}
+	user := os.Getenv("BITCOIN_TESTNET_USER")
+	if len(user) == 0 {
+		user = "bank-wallet"
+	}
 	password := os.Getenv("BITCOIN_TESTNET_PASSWORD")
-	return rpc.New(rpc.Options{
+	if len(password) == 0 {
+		password = "password1"
+	}
+
+	return createRpcClient(hostname, port, user, password)
+}
+
+func createRpcClient(hostname string, port int, user, password string) commands.RpcClient {
+	rpcClient := rpc.New(rpc.Options{
 		ServerOptions: common.ServerOptions{Protocol: "http", HostName: hostname, Port: port},
-		User:          "bank-wallet",
+		User:          user,
 		Password:      password,
 	}).Client
+
+	_, err := commands.GetBlockCount(context.Background(), rpcClient)
+	if err != nil {
+		log.Fatalf("Rpc call failed. %s.", err)
+	}
+
+	return rpcClient
 }

--- a/bitcoin/commands/commands.go
+++ b/bitcoin/commands/commands.go
@@ -29,4 +29,6 @@ const (
 	CmdSignRawTransactionWithWallet = Command("signrawtransactionwithwallet")
 	CmdSendRawTransaction           = Command("sendrawtransaction")
 	CmdTestMempoolAccept            = Command("testmempoolaccept")
+
+	CmdRawIssueAsset = Command("rawissueasset")
 )

--- a/bitcoin/commands/commands.go
+++ b/bitcoin/commands/commands.go
@@ -31,4 +31,5 @@ const (
 	CmdTestMempoolAccept            = Command("testmempoolaccept")
 
 	CmdRawIssueAsset = Command("rawissueasset")
+	CmdListIssuances = Command("listissuances")
 )

--- a/bitcoin/commands/commands.go
+++ b/bitcoin/commands/commands.go
@@ -28,4 +28,5 @@ const (
 	CmdSignRawTransactionWithKey    = Command("signrawtransactionwithkey")
 	CmdSignRawTransactionWithWallet = Command("signrawtransactionwithwallet")
 	CmdSendRawTransaction           = Command("sendrawtransaction")
+	CmdTestMempoolAccept            = Command("testmempoolaccept")
 )

--- a/bitcoin/commands/commands.go
+++ b/bitcoin/commands/commands.go
@@ -30,6 +30,7 @@ const (
 	CmdSendRawTransaction           = Command("sendrawtransaction")
 	CmdTestMempoolAccept            = Command("testmempoolaccept")
 
-	CmdRawIssueAsset = Command("rawissueasset")
-	CmdListIssuances = Command("listissuances")
+	CmdRawIssueAsset   = Command("rawissueasset")
+	CmdListIssuances   = Command("listissuances")
+	CmdRawReissueAsset = Command("rawreissueasset")
 )

--- a/bitcoin/commands/listissuances.go
+++ b/bitcoin/commands/listissuances.go
@@ -1,0 +1,17 @@
+// Copyright 2020 Condensat Tech. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+package commands
+
+import "context"
+
+func ListIssuances(ctx context.Context, rpcClient RpcClient, asset AssetID) ([]ListIssuancesInfo, error) {
+	var result []ListIssuancesInfo
+
+	err := callCommand(rpcClient, CmdListIssuances, &result, asset)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/bitcoin/commands/listunspent.go
+++ b/bitcoin/commands/listunspent.go
@@ -25,6 +25,21 @@ func ListUnspent(ctx context.Context, rpcClient RpcClient, filter []Address) ([]
 	return ListUnspentMinMaxAddressesAndOptions(ctx, rpcClient, AddressInfoMinConfirmation, AddressInfoMaxConfirmation, filter, ListUnspentOption{})
 }
 
+// ListUnspentWithAsset returns all the UTXO for the asset we're looking for
+func ListUnspentWithAsset(ctx context.Context, rpcClient RpcClient, filter []Address, asset string) ([]TransactionInfo, error) {
+	return ListUnspentMinMaxAddressesAndOptions(ctx, rpcClient, AddressInfoMinConfirmation, AddressInfoMaxConfirmation, filter, ListUnspentOption{
+		Asset: asset,
+	})
+}
+
+// ListUnspentWithAssetWithMaxCount returns maxCount UTXOs for the asset we're looking for
+func ListUnspentWithAssetWithMaxCount(ctx context.Context, rpcClient RpcClient, filter []Address, asset string, maxCount int) ([]TransactionInfo, error) {
+	return ListUnspentMinMaxAddressesAndOptions(ctx, rpcClient, AddressInfoMinConfirmation, AddressInfoMaxConfirmation, filter, ListUnspentOption{
+		Asset:        asset,
+		MaximumCount: maxCount,
+	})
+}
+
 func ListUnspentMinMaxAddressesAndOptions(ctx context.Context, rpcClient RpcClient, minConf, maxConf int, filter []Address, option ListUnspentOption) ([]TransactionInfo, error) {
 	list := make([]TransactionInfo, 0)
 	const includeUnsafe = true

--- a/bitcoin/commands/rawissueasset.go
+++ b/bitcoin/commands/rawissueasset.go
@@ -1,0 +1,59 @@
+// Copyright 2020 Condensat Tech. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+package commands
+
+import (
+	"context"
+)
+
+// RawIssueAssetWithAsset This is the minimal number of arguments you need to pass to issue an asset
+func RawIssueAssetWithAsset(ctx context.Context, rpcClient RpcClient, hex Transaction, assetAddress string, assetAmount float64) (IssuedTransaction, error) {
+	return rawIssueAssetWithOptions(ctx, rpcClient, hex, RawIssueAssetOptions{
+		AssetAmount:  assetAmount,
+		AssetAddress: assetAddress,
+		Blind:        true, //we suppose that we always want to blind issuance, maybe we should change it though
+	})
+}
+
+func RawIssueAssetWithToken(ctx context.Context, rpcClient RpcClient, hex Transaction, assetAddress string, assetAmount float64, tokenAddress string, tokenAmount float64) (IssuedTransaction, error) {
+	return rawIssueAssetWithOptions(ctx, rpcClient, hex, RawIssueAssetOptions{
+		AssetAmount:  assetAmount,
+		AssetAddress: assetAddress,
+		TokenAmount:  tokenAmount,
+		TokenAddress: tokenAddress,
+		Blind:        true,
+	})
+}
+
+func RawIssueAssetWithContract(ctx context.Context, rpcClient RpcClient, hex Transaction, assetAddress string, assetAmount float64, contractHash string) (IssuedTransaction, error) {
+	return rawIssueAssetWithOptions(ctx, rpcClient, hex, RawIssueAssetOptions{
+		AssetAmount:  assetAmount,
+		AssetAddress: assetAddress,
+		ContractHash: contractHash, //this is 64B long
+		Blind:        true,
+	})
+}
+
+func RawIssueAssetWithTokenWithContract(ctx context.Context, rpcClient RpcClient, hex Transaction, assetAddress string, assetAmount float64, tokenAddress string, tokenAmount float64, contractHash string) (IssuedTransaction, error) {
+	return rawIssueAssetWithOptions(ctx, rpcClient, hex, RawIssueAssetOptions{
+		AssetAmount:  assetAmount,
+		AssetAddress: assetAddress,
+		TokenAmount:  tokenAmount,
+		TokenAddress: tokenAddress,
+		ContractHash: contractHash, //this is 64B long
+		Blind:        true,
+	})
+}
+
+func rawIssueAssetWithOptions(ctx context.Context, rpcClient RpcClient, hex Transaction, options RawIssueAssetOptions) (IssuedTransaction, error) {
+	var result []IssuedTransaction
+	var data []interface{}
+	data = append(data, options)
+	err := callCommand(rpcClient, CmdRawIssueAsset, &result, hex, &data)
+	if err != nil {
+		return IssuedTransaction{}, err
+	}
+	return result[0], nil
+}

--- a/bitcoin/commands/rawreissueasset.go
+++ b/bitcoin/commands/rawreissueasset.go
@@ -1,0 +1,41 @@
+// Copyright 2020 Condensat Tech. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+package commands
+
+import (
+	"context"
+)
+
+// RawReissueAsset
+func RawReissueAsset(ctx context.Context,
+	rpcClient RpcClient,
+	hex Transaction,
+	assetAmount float64,
+	assetAddress, entropy, assetBlinding string,
+	inputIndex int,
+) (Transaction, error) {
+	return rawReissueAssetWithOptions(ctx, rpcClient, hex, RawReissueAssetOptions{
+		AssetAmount:  assetAmount,
+		AssetAddress: assetAddress,
+		Entropy:      entropy,
+		AssetBlinder: assetBlinding,
+		InputIndex:   inputIndex,
+	})
+}
+
+func rawReissueAssetWithOptions(ctx context.Context,
+	rpcClient RpcClient,
+	hex Transaction,
+	options RawReissueAssetOptions,
+) (Transaction, error) {
+	var result ReissuedTransaction
+	var data []interface{}
+	data = append(data, options)
+	err := callCommand(rpcClient, CmdRawReissueAsset, &result, hex, &data)
+	if err != nil {
+		return result.Hex, err
+	}
+	return result.Hex, nil
+}

--- a/bitcoin/commands/testmempoolaccept.go
+++ b/bitcoin/commands/testmempoolaccept.go
@@ -1,0 +1,25 @@
+// Copyright 2020 Condensat Tech. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+package commands
+
+import (
+	"context"
+	"errors"
+)
+
+func TestMempoolAccept(ctx context.Context, rpcClient RpcClient, hex string) (MempoolAccept, error) {
+	var result []MempoolAccept
+	var data []interface{}
+	data = append(data, []string{hex})
+	err := callCommand(rpcClient, CmdTestMempoolAccept, &result, data)
+	if err != nil {
+		return MempoolAccept{}, err
+	}
+	if len(result) != 1 {
+		return MempoolAccept{}, errors.New("invalid mempoolaccept result")
+	}
+
+	return result[0], nil
+}

--- a/bitcoin/commands/types.go
+++ b/bitcoin/commands/types.go
@@ -188,6 +188,14 @@ type RawIssueAssetOptions struct {
 	ContractHash string  `json:"contract_hash,omitempty"`
 }
 
+type RawReissueAssetOptions struct {
+	AssetAmount  float64 `json:"asset_amount"`
+	AssetAddress string  `json:"asset_address"`
+	Entropy      string  `json:"entropy"`
+	AssetBlinder string  `json:"asset_blinder"`
+	InputIndex   int     `json:"input_index"`
+}
+
 type FundedTransaction struct {
 	Changepos int     `json:"changepos"`
 	Fee       float64 `json:"fee"`
@@ -200,6 +208,10 @@ type IssuedTransaction struct {
 	Entropy string `json:"entropy"`
 	Asset   string `json:"asset"`
 	Token   string `json:"token"`
+}
+
+type ReissuedTransaction struct {
+	Hex Transaction `json:"hex"`
 }
 
 type SignedTransaction struct {

--- a/bitcoin/commands/types.go
+++ b/bitcoin/commands/types.go
@@ -178,10 +178,27 @@ type FundRawTransactionOptions struct {
 	SubtractFeeFromOutputs []int  `json:"subtractFeeFromOutputs,omitempty"`
 }
 
+type RawIssueAssetOptions struct {
+	AssetAmount  float64 `json:"asset_amount"`
+	AssetAddress string  `json:"asset_address"`
+	TokenAmount  float64 `json:"token_amount,omitempty"`
+	TokenAddress string  `json:"token_address,omitempty"`
+	Blind        bool    `json:"blind"`
+	ContractHash string  `json:"contract_hash,omitempty"`
+}
+
 type FundedTransaction struct {
 	Changepos int     `json:"changepos"`
 	Fee       float64 `json:"fee"`
 	Hex       string  `json:"hex"`
+}
+
+type IssuedTransaction struct {
+	Hex     string `json:"hex"`
+	Vout    int    `json:"vout"`
+	Entropy string `json:"entropy"`
+	Asset   string `json:"asset"`
+	Token   string `json:"token"`
 }
 
 type SignedTransaction struct {

--- a/bitcoin/commands/types.go
+++ b/bitcoin/commands/types.go
@@ -9,6 +9,7 @@ type PubKey string
 type BlindingKey string
 type Transaction string
 type TransactionID string
+type AssetID string
 
 type TransactionInfo struct {
 	// Bitcoin
@@ -210,4 +211,18 @@ type MempoolAccept struct {
 	TxID    string `json:"txid"`
 	Allowed bool   `json:"allowed"`
 	Reason  string `json:"reject-reason"`
+}
+
+type ListIssuancesInfo struct {
+	TxID         string  `json:"txid"`
+	Entropy      string  `json:"entropy"`
+	Asset        string  `json:"asset"`
+	AssetLabel   string  `json:"assetlabel"`
+	Token        string  `json:"token"`
+	Vin          int     `json:"vin"`
+	AssetAmount  float64 `json:"assetamount"`
+	TokenAmount  float64 `json:"tokenamount"`
+	IsReissuance bool    `json:"isreissuance"`
+	AssetBlinds  string  `json:"assetblinds"`
+	TokenBlinds  string  `json:"tokenblinds"`
 }

--- a/bitcoin/commands/types.go
+++ b/bitcoin/commands/types.go
@@ -188,3 +188,9 @@ type SignedTransaction struct {
 	Complete bool   `json:"complete"`
 	Hex      string `json:"hex"`
 }
+
+type MempoolAccept struct {
+	TxID    string `json:"txid"`
+	Allowed bool   `json:"allowed"`
+	Reason  string `json:"reject-reason"`
+}

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -565,6 +565,25 @@ func SpendFunds(ctx context.Context, chain string, changeAddress string, spendIn
 	return tx, nil
 }
 
+func ListIssuances(ctx context.Context, request common.ListIssuancesRequest) ([]common.IssuanceInfo, error) {
+	log := logger.Logger(ctx).WithField("Method", "wallet.ListIssuances")
+
+	log = log.WithField("Chain", request.Chain)
+
+	client := common.ChainClientFromContext(ctx, request.Chain)
+	if client == nil {
+		return nil, ErrChainClientNotFound
+	}
+
+	list, err := client.ListIssuances(ctx, request.Asset)
+	if err != nil {
+		log.WithError(err).
+			Error("Failed to list past issuances")
+		return nil, err
+	}
+	return list, nil
+}
+
 func IssueNewAsset(ctx context.Context, changeAddress string, spendInfos common.SpendInfo, request common.IssuanceRequest) (common.IssuanceResponse, error) {
 	log := logger.Logger(ctx).WithField("Method", "wallet.IssueNewAsset")
 
@@ -633,6 +652,8 @@ func getAddressInfoFromDatabase(ctx context.Context, address string, isUnconfide
 func blindTransactionFromChain(chain string) bool {
 	switch chain {
 	case "liquid-mainnet":
+		return true
+	case "liquid-regtest":
 		return true
 
 	default:

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -681,6 +681,27 @@ func ReissueAsset(ctx context.Context, changeAddress string, request common.Reis
 	return reissuance, nil
 }
 
+func BurnAsset(ctx context.Context, destAddress, changeAddress string, request common.BurnRequest) (common.BurnResponse, error) {
+	log := logger.Logger(ctx).WithField("Method", "wallet.BurnAsset")
+
+	log = log.WithField("Chain", request.Chain)
+
+	client := common.ChainClientFromContext(ctx, request.Chain)
+	if client == nil {
+		return common.BurnResponse{}, ErrChainClientNotFound
+	}
+
+	blindTransaction := blindTransactionFromChain(request.Chain)
+	burn, err := client.BurnAsset(ctx, destAddress, changeAddress, request, getAddressInfoFromDatabase, blindTransaction)
+	if err != nil {
+		log.WithError(err).
+			Error("Failed to burn asset")
+		return common.BurnResponse{}, err
+	}
+
+	return burn, nil
+}
+
 func getAddressInfoFromDatabase(ctx context.Context, address string, isUnconfidential bool) (commands.SsmPath, error) {
 	log := logger.Logger(ctx).WithField("Method", "wallet.chain.getAddressInfoFromDatabase")
 	db := appcontext.Database(ctx)

--- a/client/assetissuance.go
+++ b/client/assetissuance.go
@@ -1,0 +1,79 @@
+// Copyright 2020 Condensat Tech. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+package client
+
+import (
+	"context"
+	"errors"
+
+	"github.com/condensat/bank-core/appcontext"
+	"github.com/condensat/bank-core/logger"
+	"github.com/condensat/bank-core/messaging"
+	"github.com/condensat/bank-wallet/common"
+)
+
+const (
+	DefaultConfidentialIssuance = true
+)
+
+// AssetIssuance issues a new asset without reissuance token nor contract hash
+func AssetIssuance(ctx context.Context, chain string, issuerID uint64, assetAddress string, assetAmount float64) (common.IssuanceResponse, error) {
+	return assetIssuance(ctx, chain, DefaultConfidentialIssuance, issuerID, common.IssuanceRequest{
+		Mode:               common.AssetIssuanceModeWithAsset,
+		AssetPublicAddress: assetAddress,
+		AssetIssuedAmount:  assetAmount,
+	})
+}
+
+func AssetIssuanceWithToken(ctx context.Context, chain string, issuerID uint64, assetAddress string, assetAmount float64, tokenAddress string, tokenAmount float64) (common.IssuanceResponse, error) {
+	return assetIssuance(ctx, chain, DefaultConfidentialIssuance, issuerID, common.IssuanceRequest{
+		Mode:               common.AssetIssuanceModeWithToken,
+		AssetPublicAddress: assetAddress,
+		AssetIssuedAmount:  assetAmount,
+		TokenPublicAddress: tokenAddress,
+		TokenIssuedAmount:  tokenAmount,
+	})
+}
+
+func AssetIssuanceWithContract(ctx context.Context, chain string, issuerID uint64, assetAddress string, assetAmount float64, contractHash string) (common.IssuanceResponse, error) {
+	return assetIssuance(ctx, chain, DefaultConfidentialIssuance, issuerID, common.IssuanceRequest{
+		Mode:               common.AssetIssuanceModeWithContract,
+		AssetPublicAddress: assetAddress,
+		AssetIssuedAmount:  assetAmount,
+		ContractHash:       contractHash,
+	})
+}
+
+func AssetIssuanceWithTokenWithContract(ctx context.Context, chain string, issuerID uint64, assetAddress string, assetAmount float64, tokenAddress string, tokenAmount float64, contractHash string) (common.IssuanceResponse, error) {
+	return assetIssuance(ctx, chain, DefaultConfidentialIssuance, issuerID, common.IssuanceRequest{
+		Mode:               common.AssetIssuanceModeWithTokenWithContract,
+		AssetPublicAddress: assetAddress,
+		AssetIssuedAmount:  assetAmount,
+		TokenPublicAddress: tokenAddress,
+		TokenIssuedAmount:  tokenAmount,
+		ContractHash:       contractHash,
+	})
+}
+
+func assetIssuance(ctx context.Context, chain string, confidential bool, issuerID uint64, request common.IssuanceRequest) (common.IssuanceResponse, error) {
+	log := logger.Logger(ctx).WithField("Method", "wallet.client.assetIssuance")
+
+	request.Chain = chain
+	request.IssuerID = issuerID
+
+	if !request.IsValid() {
+		return common.IssuanceResponse{}, errors.New("Invalid Issuance info")
+	}
+
+	var result common.IssuanceResponse
+	err := messaging.RequestMessage(ctx, appcontext.AppName(ctx), common.AssetIssuanceSubject, &request, &result)
+	if err != nil {
+		log.WithError(err).
+			Error("RequestMessage failed")
+		return common.IssuanceResponse{}, messaging.ErrRequestFailed
+	}
+
+	return result, nil
+}

--- a/client/assetreissuance.go
+++ b/client/assetreissuance.go
@@ -1,0 +1,38 @@
+// Copyright 2020 Condensat Tech. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+package client
+
+import (
+	"context"
+
+	"github.com/condensat/bank-core/appcontext"
+	"github.com/condensat/bank-core/logger"
+	"github.com/condensat/bank-core/messaging"
+	"github.com/condensat/bank-wallet/common"
+)
+
+// AssetReissuance reissues an asset if provided with a token input
+func AssetReissuance(ctx context.Context, chain string, issuerID uint64, assetID, assetAddress string, assetAmount float64) (common.ReissuanceResponse, error) {
+	log := logger.Logger(ctx).WithField("Method", "wallet.client.assetReissuance")
+
+	var request common.ReissuanceRequest
+
+	request.Chain = chain
+	request.IssuerID = issuerID
+
+	request.AssetID = assetID
+	request.AssetPublicAddress = assetAddress
+	request.AssetIssuedAmount = assetAmount
+
+	var result common.ReissuanceResponse
+	err := messaging.RequestMessage(ctx, appcontext.AppName(ctx), common.AssetReissuanceSubject, &request, &result)
+	if err != nil {
+		log.WithError(err).
+			Error("RequestMessage failed")
+		return common.ReissuanceResponse{}, messaging.ErrRequestFailed
+	}
+
+	return result, nil
+}

--- a/client/burnasset.go
+++ b/client/burnasset.go
@@ -1,0 +1,37 @@
+// Copyright 2020 Condensat Tech. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+package client
+
+import (
+	"context"
+
+	"github.com/condensat/bank-core/appcontext"
+	"github.com/condensat/bank-core/logger"
+	"github.com/condensat/bank-core/messaging"
+	"github.com/condensat/bank-wallet/common"
+)
+
+// AssetBurn burns amount of asset by spending it to an unspendable output
+func AssetBurn(ctx context.Context, chain string, issuerID uint64, assetToBurn string, amountToBurn float64) (common.BurnResponse, error) {
+	log := logger.Logger(ctx).WithField("Method", "wallet.client.AssetBurn")
+
+	var request common.BurnRequest
+
+	request.Chain = chain
+	request.IssuerID = issuerID
+
+	request.Asset = assetToBurn
+	request.Amount = amountToBurn
+
+	var result common.BurnResponse
+	err := messaging.RequestMessage(ctx, appcontext.AppName(ctx), common.AssetBurnSubject, &request, &result)
+	if err != nil {
+		log.WithError(err).
+			Error("RequestMessage failed")
+		return common.BurnResponse{}, messaging.ErrRequestFailed
+	}
+
+	return result, nil
+}

--- a/client/listissuances.go
+++ b/client/listissuances.go
@@ -1,0 +1,40 @@
+// Copyright 2020 Condensat Tech. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+package client
+
+import (
+	"context"
+
+	"github.com/condensat/bank-core/appcontext"
+	"github.com/condensat/bank-core/logger"
+	"github.com/condensat/bank-core/messaging"
+	"github.com/condensat/bank-wallet/common"
+
+	"github.com/sirupsen/logrus"
+)
+
+func ListIssuances(ctx context.Context, chain string, issuerID uint64, asset string) (common.IssuanceList, error) {
+	log := logger.Logger(ctx).WithField("Method", "wallet.client.ListIssuances")
+
+	var request common.ListIssuancesRequest
+	var response common.IssuanceList
+
+	request.Chain = chain
+	request.IssuerID = issuerID
+	request.Asset = asset
+	err := messaging.RequestMessage(ctx, appcontext.AppName(ctx), common.AssetListIssuancesSubject, &request, &response)
+	if err != nil {
+		log.WithError(err).
+			Error("RequestMessage failed")
+		return common.IssuanceList{}, messaging.ErrRequestFailed
+	}
+
+	log.WithFields(logrus.Fields{
+		"Issuer ID": response.IssuerID,
+		"Count":     len(response.Issuances),
+	}).Debug("Issuances info")
+
+	return response, nil
+}

--- a/cmd/wallet-cli/Readme.md
+++ b/cmd/wallet-cli/Readme.md
@@ -1,0 +1,130 @@
+# Bank Wallet
+
+## Setup
+
+### Download and run required docker images
+
+```
+docker run --restart=always -p 4222:4222 --name nats-test -d nats:2.1-alpine
+docker run --restart=always -p 6379:6379 --name redis-test -d redis:5-alpine
+docker run --restart=always -p 3306:3306 --name mariadb-test -e MYSQL_RANDOM_ROOT_PASSWORD=yes -e MYSQL_USER=condensat -e MYSQL_PASSWORD=condensat -e MYSQL_DATABASE=condensat -v $(pwd)/tests/database/permissions.sql:/docker-entrypoint-initdb.d/permissions.sql:ro -d mariadb:10.3
+```
+
+### Clone the SSM repository and run the docker compose
+
+```
+git clone https://code.condensat.tech/global/rd/crypto-ssm.git
+cd crypto-ssm/tor
+make start
+```
+
+There might be a permission issue with the `ssm-service` dir that will prevent reading it once copied inside the container. 
+To solve this, you can `sudo chown -R 100:101 ssm-service` in your host. 
+
+### create a new wallet in the SSM
+
+Get your onion address from the `hostname` file in `ssm-service`.
+Get some entropy with `openssl rand -hex 64`.
+
+```
+export CHAIN="elements-regtest"
+export SSM_ENDPOINT="http://your_address_here.onion/api/v1
+export MASTER_ENTROPY="some random 64B"
+
+curl -s --socks5-hostname 0.0.0.0:9050 curl -i -X POST -H "Content-Type: application/json" -d '{
+        "jsonrpc": "2.0",
+        "method": "new_master",
+        "params": ["'"$CHAIN"'", "'"$MASTER_ENTROPY"'", true],
+        "id": "42"
+    }' $SSM_ENDPOINT
+
+# expected output
+HTTP/1.0 200 OK
+Content-Type: application/json
+Content-Length: 87
+Server: Werkzeug/1.0.1 Python/3.8.2
+Date: Sat, 05 Dec 2020 11:52:41 GMT
+
+{"id":"42","jsonrpc":"2.0","result":{"chain":"$CHAIN","fingerprint":"some_random_string"}}
+```
+
+If it didn't work:
+* `docker logs registry.condensat.space/crypto-ssm-tor:$(VERSION)` to see if something's wrong on the tor side
+* `docker logs registry.condensat.space/crypto-ssm:$(VERSION)` for SSM.
+
+### Create a config file
+
+Here's an example for Elements-regtest that you can save at the root of bank dir for example:
+```
+{
+  "chains": [
+    {
+      "chain": "liquid-regtest",
+      "hostname": "elements_regtest",
+      "port": $PORT,
+      "user": $USER,
+      "pass": $PASSWORD
+    }
+  ],
+  "ssm": {
+    "devices": [
+      {
+        "name": "crypto-ssm",
+        "endpoint": "http://your_onion.onion/api/v1"
+      }
+    ],
+    "chains": [
+      {
+        "device":            "crypto-ssm",
+        "chain":             "elements-regtest",
+        "fingerprint":       $FINGERPRINT,
+        "derivation_prefix": "0/0"
+      }
+    ]
+  },
+    "tor_proxy": "socks5://127.0.0.1:9050"
+}
+```
+
+The hostname must be recorded in the `/etc/hosts` file.
+$FINGERPRINT is the output of the curl command we made above.
+
+### Install and run elements in regtest
+
+## Run the server
+
+### Run bank-wallet
+
+`go run wallet/cmd/bank-wallet/main.go --cryptoMode=crypto-ssm -chains=path/to/conf --log=debug`
+
+## Run the client
+
+### Get a new deposit address
+
+`go run wallet/cmd/wallet-cli/main.go -cmd=getDepositAddress`
+
+### Send some L-BTC to the address
+
+`elements-cli sendtoaddress $ADDRESS $AMOUNT`
+
+### Issue a new asset
+
+`go run wallet/cmd/wallet-cli/main.go -cmd=issueAsset -issuanceMode=with-token-and-contract -assetAmount=1000 -tokenAmount=0.01 -contractHash="random_32B"`
+
+### Reissue an existing asset
+
+`go run wallet/cmd/wallet-cli/main.go -cmd=reissueAsset -assetAmount=1000 -assetID="some random 64B string"`
+
+### List asset issuances
+
+`go run wallet/cmd/wallet-cli/main.go -cmd=listIssuances -assetID="some random 64B string"`
+
+### Burn asset
+
+`go run wallet/cmd/wallet-cli/main.go -cmd=burnAsset -assetID="some random 64B string" -assetAmount=110`
+
+## Known Issues
+
+* Using express VPN can interact with the containers and prevent nats to work properly. If nats timeout, check that there's no vpn connection, turn it off and maybe reboot if this doesn't seem to solve the issue.
+* Using ufw can interact with the containers too, check that it's inactive with `systemctl status ufw` and turn it down with `sudo systemctl stop ufw`. Disable it with `sudo systemctl disable ufw` and reboot to make sure everything's allright.
+* If the SSM doesn't seem to work (can't generate new addresses), make sure that the fingerprint in the config file is the same than the one returned by `new-master`, and also that the chain is the same.

--- a/cmd/wallet-cli/main.go
+++ b/cmd/wallet-cli/main.go
@@ -68,6 +68,22 @@ func NextDeposit(ctx context.Context, chain string) error {
 	return nil
 }
 
+func ListIssuances(ctx context.Context, chain, asset string) error {
+	log := logger.Logger(ctx).WithField("Method", "ListIssuances")
+
+	answer, err := client.ListIssuances(ctx, chain, IssuerID, asset)
+	if err != nil {
+		return err
+	}
+
+	log.WithFields(logrus.Fields{
+		"Chain":     answer.Chain,
+		"Issuer ID": answer.IssuerID,
+		"Issuances": answer.Issuances,
+	}).Info("ListIssuances")
+	return nil
+}
+
 func AssetIssuance(ctx context.Context, chain string, issuanceMode string, assetAmount, tokenAmount float64, contractHash string) error {
 	log := logger.Logger(ctx).WithField("Method", "AssetIssuance")
 
@@ -142,6 +158,7 @@ func main() {
 	var chain string
 	var contractHash string
 	var issuanceMode string
+	var assetID string
 	var assetAmount float64
 	var tokenAmount float64
 	flag.StringVar(&command, "cmd", "", "Possible commands: [getDepositAddress, listIssuances, issueAsset, reissueAsset, burnAsset]")
@@ -150,6 +167,7 @@ func main() {
 	flag.Float64Var(&assetAmount, "assetAmount", 0.0, "amount of the new asset to issue")
 	flag.Float64Var(&tokenAmount, "tokenAmount", 0.0, "amount of the reissuance token to issue(issueAsset only)")
 	flag.StringVar(&contractHash, "contractHash", "", "hash to commit in the issuance(issueAsset only)")
+	flag.StringVar(&assetID, "assetID", "", "ID of the asset to list/reissue/burn")
 	args := parseArgs()
 
 	ctx := context.Background()
@@ -163,6 +181,8 @@ func main() {
 	switch command {
 	case "getDepositAddress":
 		err = NextDeposit(ctx, chain)
+	case "listIssuances":
+		err = ListIssuances(ctx, chain, assetID)
 	case "issueAsset":
 		err = AssetIssuance(ctx, chain, issuanceMode, assetAmount, tokenAmount, contractHash)
 	default:

--- a/cmd/wallet-cli/main.go
+++ b/cmd/wallet-cli/main.go
@@ -6,7 +6,9 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
+	"log"
 	"time"
 
 	"github.com/condensat/bank-core/appcontext"
@@ -20,6 +22,7 @@ import (
 	mprovider "github.com/condensat/bank-core/messaging/provider"
 
 	"github.com/condensat/bank-wallet/client"
+	"github.com/condensat/bank-wallet/common"
 
 	"github.com/sirupsen/logrus"
 )
@@ -30,6 +33,10 @@ type Args struct {
 	Redis cache.RedisOptions
 	Nats  mprovider.NatsOptions
 }
+
+const (
+	IssuerID uint64 = 42
+)
 
 func parseArgs() Args {
 	var args Args
@@ -43,13 +50,13 @@ func parseArgs() Args {
 	return args
 }
 
-func WalletCli(ctx context.Context) {
-	log := logger.Logger(ctx).WithField("Method", "WalletCli")
+func NextDeposit(ctx context.Context, chain string) error {
+	log := logger.Logger(ctx).WithField("Method", "NextDeposit")
 
 	// list all currencies
-	addr, err := client.CryptoAddressNextDeposit(ctx, "bitcoin-mainnet", 42)
+	addr, err := client.CryptoAddressNextDeposit(ctx, chain, 42)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	log.WithFields(logrus.Fields{
@@ -57,9 +64,92 @@ func WalletCli(ctx context.Context) {
 		"AccountID":     addr.AccountID,
 		"PublicAddress": addr.PublicAddress,
 	}).Info("CryptoAddress NextDeposit")
+
+	return nil
+}
+
+func AssetIssuance(ctx context.Context, chain string, issuanceMode string, assetAmount, tokenAmount float64, contractHash string) error {
+	log := logger.Logger(ctx).WithField("Method", "AssetIssuance")
+
+	var answer common.IssuanceResponse
+	var issuanceError error
+	switch common.AssetIssuanceMode(issuanceMode) {
+	case common.AssetIssuanceModeWithAsset:
+		assetAddress, err := client.CryptoAddressNewDeposit(ctx, chain, IssuerID)
+		if err != nil {
+			return err
+		}
+		answer, issuanceError = client.AssetIssuance(ctx, chain, IssuerID, assetAddress.PublicAddress, assetAmount)
+		if issuanceError != nil {
+			return issuanceError
+		}
+	case common.AssetIssuanceModeWithToken:
+		assetAddress, err := client.CryptoAddressNewDeposit(ctx, chain, IssuerID)
+		if err != nil {
+			return issuanceError
+		}
+		tokenAddress, err := client.CryptoAddressNewDeposit(ctx, chain, IssuerID)
+		if err != nil {
+			return issuanceError
+		}
+		answer, issuanceError = client.AssetIssuanceWithToken(ctx, chain, IssuerID, assetAddress.PublicAddress, assetAmount, tokenAddress.PublicAddress, tokenAmount)
+		if issuanceError != nil {
+			return issuanceError
+		}
+	case common.AssetIssuanceModeWithContract:
+		assetAddress, err := client.CryptoAddressNewDeposit(ctx, chain, IssuerID)
+		if err != nil {
+			return issuanceError
+		}
+		answer, issuanceError = client.AssetIssuanceWithContract(ctx, chain, IssuerID, assetAddress.PublicAddress, assetAmount, contractHash)
+		if issuanceError != nil {
+			return issuanceError
+		}
+	case common.AssetIssuanceModeWithTokenWithContract:
+		assetAddress, err := client.CryptoAddressNewDeposit(ctx, chain, IssuerID)
+		if err != nil {
+			return issuanceError
+		}
+		tokenAddress, err := client.CryptoAddressNewDeposit(ctx, chain, IssuerID)
+		if err != nil {
+			return issuanceError
+		}
+		answer, issuanceError = client.AssetIssuanceWithTokenWithContract(ctx, chain, IssuerID, assetAddress.PublicAddress, assetAmount, tokenAddress.PublicAddress, tokenAmount, contractHash)
+		if issuanceError != nil {
+			return issuanceError
+		}
+	default:
+		return errors.New("Unknown issuance mode")
+	}
+
+	log.WithFields(logrus.Fields{
+		"Chain":     answer.Chain,
+		"Issuer ID": answer.IssuerID,
+		"Asset ID":  answer.AssetID,
+		"Token ID":  answer.TokenID,
+		"TxID":      answer.TxID,
+		"Vin":       answer.Vin,
+		"AssetVout": answer.AssetVout,
+		"TokenVout": answer.TokenVout,
+		"Entropy":   answer.Entropy,
+	})
+	return issuanceError
+
 }
 
 func main() {
+	var command string
+	var chain string
+	var contractHash string
+	var issuanceMode string
+	var assetAmount float64
+	var tokenAmount float64
+	flag.StringVar(&command, "cmd", "", "Possible commands: [getDepositAddress, listIssuances, issueAsset, reissueAsset, burnAsset]")
+	flag.StringVar(&chain, "chain", "liquid-regtest", "network we'll be using")
+	flag.StringVar(&issuanceMode, "issuanceMode", "", "Possible modes: [asset-only, with-token, with-contract, with-token-and-contract] (issueAsset only)")
+	flag.Float64Var(&assetAmount, "assetAmount", 0.0, "amount of the new asset to issue")
+	flag.Float64Var(&tokenAmount, "tokenAmount", 0.0, "amount of the reissuance token to issue(issueAsset only)")
+	flag.StringVar(&contractHash, "contractHash", "", "hash to commit in the issuance(issueAsset only)")
 	args := parseArgs()
 
 	ctx := context.Background()
@@ -69,5 +159,16 @@ func main() {
 	ctx = messaging.WithMessaging(ctx, provider.NewNats(ctx, args.Nats))
 	ctx = appcontext.WithProcessusGrabber(ctx, monitor.NewProcessusGrabber(ctx, 15*time.Second))
 
-	WalletCli(ctx)
+	var err error
+	switch command {
+	case "getDepositAddress":
+		err = NextDeposit(ctx, chain)
+	case "issueAsset":
+		err = AssetIssuance(ctx, chain, issuanceMode, assetAmount, tokenAmount, contractHash)
+	default:
+		log.Fatalf("Unknown command %s", command)
+	}
+	if err != nil {
+		log.Fatalf("Command %s failed with error %v", command, err)
+	}
 }

--- a/cmd/wallet-cli/main.go
+++ b/cmd/wallet-cli/main.go
@@ -186,6 +186,31 @@ func AssetReissuance(ctx context.Context, chain string, assetID string, assetAmo
 	return nil
 }
 
+func AssetBurn(ctx context.Context, chain string, assetID string, assetAmount float64) error {
+	log := logger.Logger(ctx).WithField("Method", "AssetBurn")
+
+	if len(assetID) != 64 {
+		return errors.New("Wrong asset ID, must be 64B hexstring")
+	}
+
+	if assetAmount <= 0.0 {
+		return errors.New("Can't burn null or negative asset amount")
+	}
+
+	answer, err := client.AssetBurn(ctx, chain, IssuerID, assetID, assetAmount)
+	if err != nil {
+		return err
+	}
+
+	log.WithFields(logrus.Fields{
+		"Chain":     answer.Chain,
+		"Issuer ID": answer.IssuerID,
+		"TxID":      answer.TxID,
+		"Vout":      answer.Vout,
+	})
+	return nil
+}
+
 func main() {
 	var command string
 	var chain string
@@ -220,6 +245,8 @@ func main() {
 		err = AssetIssuance(ctx, chain, issuanceMode, assetAmount, tokenAmount, contractHash)
 	case "reissueAsset":
 		err = AssetReissuance(ctx, chain, assetID, assetAmount)
+	case "burnAsset":
+		err = AssetBurn(ctx, chain, assetID, assetAmount)
 	default:
 		log.Fatalf("Unknown command %s", command)
 	}

--- a/common/interfaces.go
+++ b/common/interfaces.go
@@ -25,6 +25,8 @@ type ChainClient interface {
 	GetTransaction(ctx context.Context, txID string) (TransactionInfo, error)
 
 	SpendFunds(ctx context.Context, changeAddress string, inputs []UTXOInfo, outputs []SpendInfo, addressInfo GetAddressInfo, blindTransaction bool) (SpendTx, error)
+
+	IssueNewAsset(ctx context.Context, changeAddress string, outputs SpendInfo, request IssuanceRequest, addressInfo GetAddressInfo, blindTransaction bool) (IssuanceResponse, error)
 }
 
 // SsmClient interface specification for crypto-ssm

--- a/common/interfaces.go
+++ b/common/interfaces.go
@@ -30,6 +30,7 @@ type ChainClient interface {
 	IssueNewAsset(ctx context.Context, changeAddress string, outputs SpendInfo, request IssuanceRequest, addressInfo GetAddressInfo, blindTransaction bool) (IssuanceResponse, error)
 	ListIssuances(ctx context.Context, asset string) ([]IssuanceInfo, error)
 	ReissueAsset(ctx context.Context, changeAddress string, input UTXOInfo, request ReissuanceRequest, addressInfo GetAddressInfo, blindTransaction bool) (ReissuanceResponse, error)
+	BurnAsset(ctx context.Context, destAddress, changeAddress string, request BurnRequest, addressInfo GetAddressInfo, blindTransaction bool) (BurnResponse, error)
 }
 
 // SsmClient interface specification for crypto-ssm

--- a/common/interfaces.go
+++ b/common/interfaces.go
@@ -20,6 +20,7 @@ type ChainClient interface {
 	GetBlockCount(ctx context.Context) (int64, error)
 	ListUnspent(ctx context.Context, minConf, maxConf int, addresses ...string) ([]TransactionInfo, error)
 	ListUnspentByAsset(ctx context.Context, minConf, maxConf int, asset string) ([]TransactionInfo, error)
+	ListUnspentWithAssetWithMaxCount(ctx context.Context, minConf, maxConf int, asset string, maxCount int) ([]TransactionInfo, error)
 	LockUnspent(ctx context.Context, unlock bool, transactions ...TransactionInfo) error
 	ListLockUnspent(ctx context.Context) ([]TransactionInfo, error)
 	GetTransaction(ctx context.Context, txID string) (TransactionInfo, error)
@@ -28,6 +29,7 @@ type ChainClient interface {
 
 	IssueNewAsset(ctx context.Context, changeAddress string, outputs SpendInfo, request IssuanceRequest, addressInfo GetAddressInfo, blindTransaction bool) (IssuanceResponse, error)
 	ListIssuances(ctx context.Context, asset string) ([]IssuanceInfo, error)
+	ReissueAsset(ctx context.Context, changeAddress string, input UTXOInfo, request ReissuanceRequest, addressInfo GetAddressInfo, blindTransaction bool) (ReissuanceResponse, error)
 }
 
 // SsmClient interface specification for crypto-ssm

--- a/common/interfaces.go
+++ b/common/interfaces.go
@@ -27,6 +27,7 @@ type ChainClient interface {
 	SpendFunds(ctx context.Context, changeAddress string, inputs []UTXOInfo, outputs []SpendInfo, addressInfo GetAddressInfo, blindTransaction bool) (SpendTx, error)
 
 	IssueNewAsset(ctx context.Context, changeAddress string, outputs SpendInfo, request IssuanceRequest, addressInfo GetAddressInfo, blindTransaction bool) (IssuanceResponse, error)
+	ListIssuances(ctx context.Context, asset string) ([]IssuanceInfo, error)
 }
 
 // SsmClient interface specification for crypto-ssm

--- a/common/messaging.go
+++ b/common/messaging.go
@@ -13,4 +13,6 @@ const (
 
 	WalletStatusSubject = chanPrefix + "WalletStatus"
 	WalletListSubject   = chanPrefix + "WalletList"
+
+	AssetIssuanceSubject = chanPrefix + "Asset.Issuance"
 )

--- a/common/messaging.go
+++ b/common/messaging.go
@@ -16,4 +16,5 @@ const (
 
 	AssetListIssuancesSubject = chanPrefix + "Asset.ListIssuances"
 	AssetIssuanceSubject      = chanPrefix + "Asset.Issuance"
+	AssetReissuanceSubject    = chanPrefix + "Asset.Reissuance"
 )

--- a/common/messaging.go
+++ b/common/messaging.go
@@ -17,4 +17,5 @@ const (
 	AssetListIssuancesSubject = chanPrefix + "Asset.ListIssuances"
 	AssetIssuanceSubject      = chanPrefix + "Asset.Issuance"
 	AssetReissuanceSubject    = chanPrefix + "Asset.Reissuance"
+	AssetBurnSubject          = chanPrefix + "Asset.Burn"
 )

--- a/common/messaging.go
+++ b/common/messaging.go
@@ -14,5 +14,6 @@ const (
 	WalletStatusSubject = chanPrefix + "WalletStatus"
 	WalletListSubject   = chanPrefix + "WalletList"
 
-	AssetIssuanceSubject = chanPrefix + "Asset.Issuance"
+	AssetListIssuancesSubject = chanPrefix + "Asset.ListIssuances"
+	AssetIssuanceSubject      = chanPrefix + "Asset.Issuance"
 )

--- a/common/types.go
+++ b/common/types.go
@@ -21,6 +21,10 @@ type ServerOptions struct {
 	Port     int
 }
 
+const (
+	ElementsRegtestHash string = "b2e15d0d7a0c94e4e2ce0fe6e8691b9e451377f6e46e8045a86f7c4b5d4f0f23"
+)
+
 type CryptoAddress struct {
 	CryptoAddressID  uint64
 	Chain            string

--- a/common/types.go
+++ b/common/types.go
@@ -173,6 +173,20 @@ type ReissuanceResponse struct {
 	TokenVout int    // vout of the reissuance token: this is what we will need next time to issue
 }
 
+type BurnRequest struct {
+	Chain    string
+	IssuerID uint64
+	Asset    string  // asset to burn
+	Amount   float64 // amount of asset to burn
+}
+
+type BurnResponse struct {
+	Chain    string
+	IssuerID uint64
+	TxID     string // txid of the transaction that burned the asset
+	Vout     int    // index of the OP_RETURN output that burn the asset
+}
+
 type WalletInfo struct {
 	Chain  string
 	Height int
@@ -260,6 +274,22 @@ func (p *ReissuanceResponse) Encode() ([]byte, error) {
 }
 
 func (p *ReissuanceResponse) Decode(data []byte) error {
+	return messaging.DecodeObject(data, messaging.BankObject(p))
+}
+
+func (p *BurnRequest) Encode() ([]byte, error) {
+	return messaging.EncodeObject(p)
+}
+
+func (p *BurnRequest) Decode(data []byte) error {
+	return messaging.DecodeObject(data, messaging.BankObject(p))
+}
+
+func (p *BurnResponse) Encode() ([]byte, error) {
+	return messaging.EncodeObject(p)
+}
+
+func (p *BurnResponse) Decode(data []byte) error {
 	return messaging.DecodeObject(data, messaging.BankObject(p))
 }
 

--- a/common/types.go
+++ b/common/types.go
@@ -93,6 +93,31 @@ type SpendTx struct {
 	TxID string
 }
 
+type ListIssuancesRequest struct {
+	Chain    string
+	IssuerID uint64
+	Asset    string
+}
+
+type IssuanceInfo struct {
+	TxID         string  // TxID of the issuance
+	Entropy      string  // We need it for reissuances
+	Asset        string  // Asset ID (64B hex)
+	Token        string  // reissuance token ID, computed from asset ID
+	Vin          int     // index of the input the issuance is "hooked" to
+	AssetAmount  float64 // amount issued of the asset
+	TokenAmount  float64 // amount of reissuance token (can't be reissued)
+	IsReissuance bool    // false == initial issuance
+	AssetBlinds  string  // blinding factor for the amount of asset issued
+	TokenBlinds  string  // blinding factor for the amount of token issued
+}
+
+type IssuanceList struct {
+	Chain     string
+	IssuerID  uint64
+	Issuances []IssuanceInfo
+}
+
 type IssuanceRequest struct {
 	Chain              string            // mainly elements-regtest or LiquidV1 now, but can be useful for other chains later
 	IssuerID           uint64            // User ID used for communication with our db
@@ -157,6 +182,22 @@ func (p *WalletStatus) Encode() ([]byte, error) {
 }
 
 func (p *WalletStatus) Decode(data []byte) error {
+	return messaging.DecodeObject(data, messaging.BankObject(p))
+}
+
+func (p *ListIssuancesRequest) Encode() ([]byte, error) {
+	return messaging.EncodeObject(p)
+}
+
+func (p *ListIssuancesRequest) Decode(data []byte) error {
+	return messaging.DecodeObject(data, messaging.BankObject(p))
+}
+
+func (p *IssuanceList) Encode() ([]byte, error) {
+	return messaging.EncodeObject(p)
+}
+
+func (p *IssuanceList) Decode(data []byte) error {
 	return messaging.DecodeObject(data, messaging.BankObject(p))
 }
 

--- a/common/types_test.go
+++ b/common/types_test.go
@@ -1,0 +1,213 @@
+// Copyright 2020 Condensat Tech. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+package common
+
+import (
+	"testing"
+)
+
+func TestIssuanceInfo_IsValid_Mode(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		Mode               AssetIssuanceMode
+		AssetPublicAddress string
+		AssetIssuedAmount  float64
+		TokenPublicAddress string
+		TokenIssuedAmount  float64
+		ContractHash       string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{"default", fields{}, false},
+		{"invalid", fields{Mode: "foobar"}, false},
+
+		{"issueAsset", fields{Mode: AssetIssuanceModeWithAsset, AssetPublicAddress: "foobar", AssetIssuedAmount: 42.1}, true},
+		{"issueAssetWithToken", fields{Mode: AssetIssuanceModeWithToken, AssetPublicAddress: "foobar", AssetIssuedAmount: 42.1, TokenPublicAddress: "foobar", TokenIssuedAmount: 42.1}, true},
+		{"issueAssetWithContract", fields{Mode: AssetIssuanceModeWithContract, AssetPublicAddress: "foobar", AssetIssuedAmount: 42.1, ContractHash: "contract"}, true},
+		{"issueAssetWithTokenWithContract", fields{Mode: AssetIssuanceModeWithTokenWithContract, AssetPublicAddress: "foobar", AssetIssuedAmount: 42.1, TokenPublicAddress: "foobar", TokenIssuedAmount: 42.1, ContractHash: "contract"}, true},
+	}
+	for _, tt := range tests {
+		tt := tt // capture range variable
+		t.Run(tt.name, func(t *testing.T) {
+			p := &IssuanceRequest{
+				Mode:               tt.fields.Mode,
+				AssetPublicAddress: tt.fields.AssetPublicAddress,
+				AssetIssuedAmount:  tt.fields.AssetIssuedAmount,
+				TokenPublicAddress: tt.fields.TokenPublicAddress,
+				TokenIssuedAmount:  tt.fields.TokenIssuedAmount,
+				ContractHash:       tt.fields.ContractHash,
+			}
+			if got := p.IsValid(); got != tt.want {
+				t.Errorf("IssuanceInfo.IsValid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIssuanceInfo_IsValid_WithAsset(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		AssetPublicAddress string
+		AssetIssuedAmount  float64
+		TokenPublicAddress string
+		TokenIssuedAmount  float64
+		ContractHash       string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{"default", fields{}, false},
+		{"invalidAddress", fields{AssetIssuedAmount: 42.1}, false},
+		{"invalidAmount", fields{AssetPublicAddress: "foobar"}, false},
+
+		{"invalidContract", fields{AssetPublicAddress: "foobar", AssetIssuedAmount: 42.1, ContractHash: "invalid"}, false},
+
+		{"valid", fields{AssetPublicAddress: "foobar", AssetIssuedAmount: 42.1}, true},
+	}
+	for _, tt := range tests {
+		tt := tt // capture range variable
+		t.Run(tt.name, func(t *testing.T) {
+			p := &IssuanceRequest{
+				Mode:               AssetIssuanceModeWithAsset,
+				AssetPublicAddress: tt.fields.AssetPublicAddress,
+				AssetIssuedAmount:  tt.fields.AssetIssuedAmount,
+				ContractHash:       tt.fields.ContractHash,
+			}
+			if got := p.IsValid(); got != tt.want {
+				t.Errorf("IssuanceInfo.IsValid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIssuanceInfo_IsValid_WithToken(t *testing.T) {
+	t.Parallel()
+	type fields struct {
+		Mode               AssetIssuanceMode
+		AssetPublicAddress string
+		AssetIssuedAmount  float64
+		TokenPublicAddress string
+		TokenIssuedAmount  float64
+		ContractHash       string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{"default", fields{}, false},
+		{"invalidAssetAddress", fields{AssetIssuedAmount: 42.1, TokenPublicAddress: "foobar", TokenIssuedAmount: 42.1}, false},
+		{"invalidAssetAmount", fields{AssetPublicAddress: "foobar", TokenPublicAddress: "foobar", TokenIssuedAmount: 42.1}, false},
+		{"invalidTokenAddress", fields{AssetPublicAddress: "foobar", AssetIssuedAmount: 42.1, TokenIssuedAmount: 42.1}, false},
+		{"invalidTokenAmount", fields{AssetPublicAddress: "foobar", AssetIssuedAmount: 42.1, TokenPublicAddress: "foobar"}, false},
+
+		{"invalidContractHash", fields{AssetPublicAddress: "foobar", AssetIssuedAmount: 42.1, TokenPublicAddress: "foobar", TokenIssuedAmount: 42.1, ContractHash: "contract"}, false},
+
+		{"valid", fields{AssetPublicAddress: "foobar", AssetIssuedAmount: 42.1, TokenPublicAddress: "foobar", TokenIssuedAmount: 42.1}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &IssuanceRequest{
+				Mode:               AssetIssuanceModeWithToken,
+				AssetPublicAddress: tt.fields.AssetPublicAddress,
+				AssetIssuedAmount:  tt.fields.AssetIssuedAmount,
+				TokenPublicAddress: tt.fields.TokenPublicAddress,
+				TokenIssuedAmount:  tt.fields.TokenIssuedAmount,
+				ContractHash:       tt.fields.ContractHash,
+			}
+			if got := p.IsValid(); got != tt.want {
+				t.Errorf("IssuanceInfo.IsValid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIssuanceInfo_IsValid_WithContract(t *testing.T) {
+	type fields struct {
+		Mode               AssetIssuanceMode
+		AssetPublicAddress string
+		AssetIssuedAmount  float64
+		TokenPublicAddress string
+		TokenIssuedAmount  float64
+		ContractHash       string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{"default", fields{}, false},
+		{"invalidAssetAddress", fields{AssetIssuedAmount: 42.1, ContractHash: "contract"}, false},
+		{"invalidAssetAmount", fields{AssetPublicAddress: "foobar", ContractHash: "contract"}, false},
+		{"invalidContractHash", fields{AssetPublicAddress: "foobar", AssetIssuedAmount: 42.1}, false},
+
+		{"invalidTokenAddress", fields{AssetPublicAddress: "foobar", AssetIssuedAmount: 42.1, TokenIssuedAmount: 42.1, ContractHash: "contract"}, false},
+		{"invalidTokenAmount", fields{AssetPublicAddress: "foobar", AssetIssuedAmount: 42.1, TokenPublicAddress: "foobar", ContractHash: "contract"}, false},
+
+		{"valid", fields{AssetPublicAddress: "foobar", AssetIssuedAmount: 42.1, ContractHash: "contract"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &IssuanceRequest{
+				Mode:               AssetIssuanceModeWithContract,
+				AssetPublicAddress: tt.fields.AssetPublicAddress,
+				AssetIssuedAmount:  tt.fields.AssetIssuedAmount,
+				TokenPublicAddress: tt.fields.TokenPublicAddress,
+				TokenIssuedAmount:  tt.fields.TokenIssuedAmount,
+				ContractHash:       tt.fields.ContractHash,
+			}
+			if got := p.IsValid(); got != tt.want {
+				t.Errorf("IssuanceInfo.IsValid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIssuanceInfo_IsValid_WithTokenWithContract(t *testing.T) {
+	type fields struct {
+		Mode               AssetIssuanceMode
+		AssetPublicAddress string
+		AssetIssuedAmount  float64
+		TokenPublicAddress string
+		TokenIssuedAmount  float64
+		ContractHash       string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{"default", fields{}, false},
+		{"invalidAssetAddress", fields{AssetIssuedAmount: 42.1, TokenPublicAddress: "foobar", TokenIssuedAmount: 42.1, ContractHash: "contract"}, false},
+		{"invalidAssetAmount", fields{AssetPublicAddress: "foobar", TokenPublicAddress: "foobar", TokenIssuedAmount: 42.1, ContractHash: "contract"}, false},
+		{"invalidTokenAddress", fields{AssetPublicAddress: "foobar", AssetIssuedAmount: 42.1, TokenIssuedAmount: 42.1, ContractHash: "contract"}, false},
+		{"invalidTokenAmount", fields{AssetPublicAddress: "foobar", AssetIssuedAmount: 42.1, TokenPublicAddress: "foobar", ContractHash: "contract"}, false},
+		{"invalidContractHash", fields{AssetPublicAddress: "foobar", AssetIssuedAmount: 42.1, TokenPublicAddress: "foobar", TokenIssuedAmount: 42.1}, false},
+
+		{"valid", fields{AssetPublicAddress: "foobar", AssetIssuedAmount: 42.1, TokenPublicAddress: "foobar", TokenIssuedAmount: 42.1, ContractHash: "contract"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &IssuanceRequest{
+				Mode:               AssetIssuanceModeWithTokenWithContract,
+				AssetPublicAddress: tt.fields.AssetPublicAddress,
+				AssetIssuedAmount:  tt.fields.AssetIssuedAmount,
+				TokenPublicAddress: tt.fields.TokenPublicAddress,
+				TokenIssuedAmount:  tt.fields.TokenIssuedAmount,
+				ContractHash:       tt.fields.ContractHash,
+			}
+			if got := p.IsValid(); got != tt.want {
+				t.Errorf("IssuanceInfo.IsValid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/handlers/assetissuance.go
+++ b/handlers/assetissuance.go
@@ -1,0 +1,126 @@
+// Copyright 2020 Condensat Tech. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+package handlers
+
+import (
+	"context"
+	"errors"
+
+	"github.com/condensat/bank-core/appcontext"
+	"github.com/condensat/bank-core/logger"
+
+	"github.com/condensat/bank-wallet/common"
+
+	"github.com/condensat/bank-core/cache"
+	"github.com/condensat/bank-core/messaging"
+
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	ErrChainClientNotFound = errors.New("Client not found")
+	ErrInvalidIssuanceInfo = errors.New("Provided Issuance Info are invalid")
+	ErrCantGetAddress      = errors.New("Can't get a new address")
+	ErrCreatingTransaction = errors.New("Can't create transaction for issuance")
+)
+
+const (
+	DefaultAmountForIssuance = 0.1
+)
+
+func AssetIssuance(ctx context.Context, request common.IssuanceRequest) (common.IssuanceResponse, error) {
+	log := logger.Logger(ctx).WithField("Method", "wallet.AssetIssuance")
+
+	// sanity check for different mode
+	if !request.IsValid() {
+		log.Errorf("Mode %s is invalid", string(request.Mode))
+		return common.IssuanceResponse{}, ErrInvalidIssuanceInfo
+	}
+
+	chainHandler := ChainHandlerFromContext(ctx)
+	if chainHandler == nil {
+		log.Error("Failed to ChainHandlerFromContext")
+		return common.IssuanceResponse{}, errors.New("Something's wrong with the chainHandler")
+	}
+
+	bankAddress, err := CryptoAddressNewDeposit(ctx, common.CryptoAddress{
+		Chain:     request.Chain,
+		AccountID: request.IssuerID,
+	})
+	if err != nil {
+		log.WithError(err).
+			Error("Failed to CryptoAddressNewDeposit")
+		return common.IssuanceResponse{}, ErrCantGetAddress
+	}
+
+	destAddress := bankAddress.PublicAddress
+	if len(destAddress) == 0 {
+		log.WithError(err).
+			Error("destination address is empty")
+		return common.IssuanceResponse{}, ErrCantGetAddress
+	}
+
+	bankAddress, err = CryptoAddressNewDeposit(ctx, common.CryptoAddress{
+		Chain:     request.Chain,
+		AccountID: request.IssuerID,
+	})
+	if err != nil {
+		log.WithError(err).
+			Error("Failed to CryptoAddressNewDeposit")
+		return common.IssuanceResponse{}, ErrCantGetAddress
+	}
+
+	changeAddress := bankAddress.PublicAddress
+	if len(changeAddress) == 0 {
+		log.WithError(err).
+			Error("destination address is empty")
+		return common.IssuanceResponse{}, ErrCantGetAddress
+	}
+
+	// The amount of the LBTC output doesn't matter much, as long as it is enough to pay fees and not leave dust
+	// Maybe we could first use a relatively high amount to be safe, and see later
+	output := common.SpendInfo{
+		PublicAddress: destAddress,
+		Amount:        DefaultAmountForIssuance,
+	}
+
+	return chainHandler.IssueNewAsset(ctx, changeAddress, output, request)
+}
+
+func OnAssetIssuance(ctx context.Context, subject string, message *messaging.Message) (*messaging.Message, error) {
+	log := logger.Logger(ctx).WithField("Method", "wallet.OnAssetIssuance")
+	log = log.WithFields(logrus.Fields{
+		"Subject": subject,
+	})
+
+	var request common.IssuanceRequest
+	return messaging.HandleRequest(ctx, appcontext.AppName(ctx), message, &request,
+		func(ctx context.Context, _ messaging.BankObject) (messaging.BankObject, error) {
+			log = log.WithFields(logrus.Fields{
+				"Chain":    request.Chain,
+				"IssuerID": request.IssuerID,
+			})
+
+			info, err := AssetIssuance(ctx, request)
+			if err != nil {
+				log.WithError(err).
+					Errorf("Failed to AssetIssuance")
+				return nil, cache.ErrInternalError
+			}
+
+			// create & return response
+			return &common.IssuanceResponse{
+				Chain:     info.Chain,
+				IssuerID:  info.IssuerID,
+				AssetID:   info.AssetID,
+				TokenID:   info.TokenID,
+				TxID:      info.TxID,
+				Vin:       info.Vin,
+				AssetVout: info.AssetVout,
+				TokenVout: info.TokenVout,
+				Entropy:   info.Entropy,
+			}, nil
+		})
+}

--- a/handlers/assetreissuance.go
+++ b/handlers/assetreissuance.go
@@ -1,0 +1,101 @@
+// Copyright 2020 Condensat Tech. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+package handlers
+
+import (
+	"context"
+	"errors"
+
+	"github.com/condensat/bank-core/appcontext"
+	"github.com/condensat/bank-core/logger"
+
+	"github.com/condensat/bank-wallet/common"
+
+	"github.com/condensat/bank-core/cache"
+	"github.com/condensat/bank-core/messaging"
+
+	"github.com/sirupsen/logrus"
+)
+
+func AssetReissuance(ctx context.Context, request common.ReissuanceRequest) (common.ReissuanceResponse, error) {
+	log := logger.Logger(ctx).WithField("Method", "wallet.AssetReissuance")
+
+	chainHandler := ChainHandlerFromContext(ctx)
+	if chainHandler == nil {
+		log.Error("Failed to ChainHandlerFromContext")
+		return common.ReissuanceResponse{}, errors.New("Something's wrong with the chainHandler")
+	}
+
+	bankAddress, err := CryptoAddressNewDeposit(ctx, common.CryptoAddress{
+		Chain:     request.Chain,
+		AccountID: request.IssuerID,
+	})
+	if err != nil {
+		log.WithError(err).
+			Error("Failed to CryptoAddressNewDeposit")
+		return common.ReissuanceResponse{}, ErrCantGetAddress
+	}
+
+	destAddress := bankAddress.PublicAddress
+	if len(destAddress) == 0 {
+		log.WithError(err).
+			Error("destination address is empty")
+		return common.ReissuanceResponse{}, ErrCantGetAddress
+	}
+
+	bankAddress, err = CryptoAddressNewDeposit(ctx, common.CryptoAddress{
+		Chain:     request.Chain,
+		AccountID: request.IssuerID,
+	})
+	if err != nil {
+		log.WithError(err).
+			Error("Failed to CryptoAddressNewDeposit")
+		return common.ReissuanceResponse{}, ErrCantGetAddress
+	}
+
+	changeAddress := bankAddress.PublicAddress
+	if len(changeAddress) == 0 {
+		log.WithError(err).
+			Error("destination address is empty")
+		return common.ReissuanceResponse{}, ErrCantGetAddress
+	}
+
+	// This is the token output, but since we spend the whole output we can just complete amount next step
+	request.TokenPublicAddress = destAddress
+
+	return chainHandler.ReissueAsset(ctx, changeAddress, request)
+}
+
+func OnAssetReissuance(ctx context.Context, subject string, message *messaging.Message) (*messaging.Message, error) {
+	log := logger.Logger(ctx).WithField("Method", "wallet.OnAssetReissuance")
+	log = log.WithFields(logrus.Fields{
+		"Subject": subject,
+	})
+
+	var request common.ReissuanceRequest
+	return messaging.HandleRequest(ctx, appcontext.AppName(ctx), message, &request,
+		func(ctx context.Context, _ messaging.BankObject) (messaging.BankObject, error) {
+			log = log.WithFields(logrus.Fields{
+				"Chain":    request.Chain,
+				"IssuerID": request.IssuerID,
+			})
+
+			info, err := AssetReissuance(ctx, request)
+			if err != nil {
+				log.WithError(err).
+					Errorf("Failed to AssetReissuance")
+				return nil, cache.ErrInternalError
+			}
+
+			// create & return response
+			return &common.ReissuanceResponse{
+				Chain:     info.Chain,
+				IssuerID:  info.IssuerID,
+				TxID:      info.TxID,
+				AssetVout: info.AssetVout,
+				TokenVout: info.TokenVout,
+			}, nil
+		})
+}

--- a/handlers/burnasset.go
+++ b/handlers/burnasset.go
@@ -1,0 +1,96 @@
+// Copyright 2020 Condensat Tech. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+package handlers
+
+import (
+	"context"
+	"errors"
+
+	"github.com/condensat/bank-core/appcontext"
+	"github.com/condensat/bank-core/logger"
+
+	"github.com/condensat/bank-wallet/common"
+
+	"github.com/condensat/bank-core/cache"
+	"github.com/condensat/bank-core/messaging"
+
+	"github.com/sirupsen/logrus"
+)
+
+func AssetBurn(ctx context.Context, request common.BurnRequest) (common.BurnResponse, error) {
+	log := logger.Logger(ctx).WithField("Method", "wallet.AssetBurn")
+
+	chainHandler := ChainHandlerFromContext(ctx)
+	if chainHandler == nil {
+		log.Error("Failed to ChainHandlerFromContext")
+		return common.BurnResponse{}, errors.New("Something's wrong with the chainHandler")
+	}
+
+	bankAddress, err := CryptoAddressNewDeposit(ctx, common.CryptoAddress{
+		Chain:     request.Chain,
+		AccountID: request.IssuerID,
+	})
+	if err != nil {
+		log.WithError(err).
+			Error("Failed to CryptoAddressNewDeposit")
+		return common.BurnResponse{}, ErrCantGetAddress
+	}
+
+	destAddress := bankAddress.PublicAddress
+	if len(destAddress) == 0 {
+		log.WithError(err).
+			Error("destination address is empty")
+		return common.BurnResponse{}, ErrCantGetAddress
+	}
+
+	bankAddress, err = CryptoAddressNewDeposit(ctx, common.CryptoAddress{
+		Chain:     request.Chain,
+		AccountID: request.IssuerID,
+	})
+	if err != nil {
+		log.WithError(err).
+			Error("Failed to CryptoAddressNewDeposit")
+		return common.BurnResponse{}, ErrCantGetAddress
+	}
+
+	changeAddress := bankAddress.PublicAddress
+	if len(changeAddress) == 0 {
+		log.WithError(err).
+			Error("destination address is empty")
+		return common.BurnResponse{}, ErrCantGetAddress
+	}
+
+	return chainHandler.BurnAsset(ctx, destAddress, changeAddress, request)
+}
+
+func OnAssetBurn(ctx context.Context, subject string, message *messaging.Message) (*messaging.Message, error) {
+	log := logger.Logger(ctx).WithField("Method", "wallet.OnAssetBurn")
+	log = log.WithFields(logrus.Fields{
+		"Subject": subject,
+	})
+
+	var request common.BurnRequest
+	return messaging.HandleRequest(ctx, appcontext.AppName(ctx), message, &request,
+		func(ctx context.Context, _ messaging.BankObject) (messaging.BankObject, error) {
+			log = log.WithFields(logrus.Fields{
+				"Chain":    request.Chain,
+				"IssuerID": request.IssuerID,
+			})
+
+			info, err := AssetBurn(ctx, request)
+			if err != nil {
+				log.WithError(err).
+					Errorf("Failed to AssetBurn")
+				return nil, cache.ErrInternalError
+			}
+
+			// create & return response
+			return &common.BurnResponse{
+				Chain:    info.Chain,
+				IssuerID: info.IssuerID,
+				TxID:     info.TxID,
+			}, nil
+		})
+}

--- a/handlers/context.go
+++ b/handlers/context.go
@@ -28,6 +28,7 @@ type ChainHandler interface {
 
 	WalletInfo(ctx context.Context, chain string) (common.WalletInfo, error)
 
+	ListIssuances(ctx context.Context, request common.ListIssuancesRequest) ([]common.IssuanceInfo, error)
 	IssueNewAsset(ctx context.Context, changeAddress string, spendInfos common.SpendInfo, request common.IssuanceRequest) (common.IssuanceResponse, error)
 }
 

--- a/handlers/context.go
+++ b/handlers/context.go
@@ -31,6 +31,7 @@ type ChainHandler interface {
 	ListIssuances(ctx context.Context, request common.ListIssuancesRequest) ([]common.IssuanceInfo, error)
 	IssueNewAsset(ctx context.Context, changeAddress string, spendInfos common.SpendInfo, request common.IssuanceRequest) (common.IssuanceResponse, error)
 	ReissueAsset(ctx context.Context, changeAddress string, request common.ReissuanceRequest) (common.ReissuanceResponse, error)
+	BurnAsset(ctx context.Context, destAddress, changeAddress string, request common.BurnRequest) (common.BurnResponse, error)
 }
 
 func ChainHandlerContext(ctx context.Context, chain ChainHandler) context.Context {

--- a/handlers/context.go
+++ b/handlers/context.go
@@ -30,6 +30,7 @@ type ChainHandler interface {
 
 	ListIssuances(ctx context.Context, request common.ListIssuancesRequest) ([]common.IssuanceInfo, error)
 	IssueNewAsset(ctx context.Context, changeAddress string, spendInfos common.SpendInfo, request common.IssuanceRequest) (common.IssuanceResponse, error)
+	ReissueAsset(ctx context.Context, changeAddress string, request common.ReissuanceRequest) (common.ReissuanceResponse, error)
 }
 
 func ChainHandlerContext(ctx context.Context, chain ChainHandler) context.Context {

--- a/handlers/context.go
+++ b/handlers/context.go
@@ -27,6 +27,8 @@ type ChainHandler interface {
 	GetAddressInfo(ctx context.Context, chain, address string) (common.AddressInfo, error)
 
 	WalletInfo(ctx context.Context, chain string) (common.WalletInfo, error)
+
+	IssueNewAsset(ctx context.Context, changeAddress string, spendInfos common.SpendInfo, request common.IssuanceRequest) (common.IssuanceResponse, error)
 }
 
 func ChainHandlerContext(ctx context.Context, chain ChainHandler) context.Context {

--- a/handlers/cryptoaddressnew.go
+++ b/handlers/cryptoaddressnew.go
@@ -267,6 +267,9 @@ func convertToSsmChain(chain model.String) model.SsmChain {
 	case "liquid-mainnet":
 		return "liquidv1"
 
+	case "liquid-regtest":
+		return "elements-regtest"
+
 	default:
 		return ""
 	}

--- a/handlers/listissuances.go
+++ b/handlers/listissuances.go
@@ -1,0 +1,61 @@
+// Copyright 2020 Condensat Tech. All rights reserved.
+// Use of this source code is governed by a MIT
+// license that can be found in the LICENSE file.
+
+package handlers
+
+import (
+	"context"
+	"errors"
+
+	"github.com/condensat/bank-core/appcontext"
+	"github.com/condensat/bank-core/logger"
+
+	"github.com/condensat/bank-wallet/common"
+
+	"github.com/condensat/bank-core/cache"
+	"github.com/condensat/bank-core/messaging"
+
+	"github.com/sirupsen/logrus"
+)
+
+func ListIssuances(ctx context.Context, request common.ListIssuancesRequest) ([]common.IssuanceInfo, error) {
+	log := logger.Logger(ctx).WithField("Method", "wallet.AssetIssuance")
+
+	chainHandler := ChainHandlerFromContext(ctx)
+	if chainHandler == nil {
+		log.Error("Failed to ChainHandlerFromContext")
+		return []common.IssuanceInfo{}, errors.New("Something's wrong with the chainHandler")
+	}
+
+	return chainHandler.ListIssuances(ctx, request)
+}
+
+func OnListIssuances(ctx context.Context, subject string, message *messaging.Message) (*messaging.Message, error) {
+	log := logger.Logger(ctx).WithField("Method", "wallet.OnListIssuances")
+	log = log.WithFields(logrus.Fields{
+		"Subject": subject,
+	})
+
+	var request common.ListIssuancesRequest
+	return messaging.HandleRequest(ctx, appcontext.AppName(ctx), message, &request,
+		func(ctx context.Context, _ messaging.BankObject) (messaging.BankObject, error) {
+			log = log.WithFields(logrus.Fields{
+				"Chain":    request.Chain,
+				"IssuerID": request.IssuerID,
+			})
+
+			list, err := ListIssuances(ctx, request)
+			if err != nil {
+				log.WithError(err).
+					Errorf("Failed to ListIssuances")
+				return nil, cache.ErrInternalError
+			}
+
+			return &common.IssuanceList{
+				Chain:     request.Chain,
+				IssuerID:  request.IssuerID,
+				Issuances: list,
+			}, nil
+		})
+}

--- a/wallet.go
+++ b/wallet.go
@@ -134,6 +134,7 @@ func (p *Wallet) registerHandlers(ctx context.Context) context.Context {
 
 	nats.SubscribeWorkers(ctx, common.WalletStatusSubject, concurencyLevel, handlers.OnWalletStatus)
 	nats.SubscribeWorkers(ctx, common.WalletListSubject, concurencyLevel, handlers.OnWalletList)
+	nats.SubscribeWorkers(ctx, common.AssetIssuanceSubject, concurencyLevel, handlers.OnAssetIssuance)
 
 	log.Debug("Bank Wallet registered")
 	return ctx
@@ -246,4 +247,8 @@ func (p *Wallet) GetAddressInfo(ctx context.Context, chainName, address string) 
 
 func (p *Wallet) WalletInfo(ctx context.Context, chainName string) (common.WalletInfo, error) {
 	return chain.WalletInfo(ctx, chainName)
+}
+
+func (p *Wallet) IssueNewAsset(ctx context.Context, changeAddress string, spendInfos common.SpendInfo, request common.IssuanceRequest) (common.IssuanceResponse, error) {
+	return chain.IssueNewAsset(ctx, changeAddress, spendInfos, request)
 }

--- a/wallet.go
+++ b/wallet.go
@@ -137,6 +137,7 @@ func (p *Wallet) registerHandlers(ctx context.Context) context.Context {
 	nats.SubscribeWorkers(ctx, common.AssetListIssuancesSubject, concurencyLevel, handlers.OnListIssuances)
 	nats.SubscribeWorkers(ctx, common.AssetIssuanceSubject, concurencyLevel, handlers.OnAssetIssuance)
 	nats.SubscribeWorkers(ctx, common.AssetReissuanceSubject, concurencyLevel, handlers.OnAssetReissuance)
+	nats.SubscribeWorkers(ctx, common.AssetBurnSubject, concurencyLevel, handlers.OnAssetBurn)
 
 	log.Debug("Bank Wallet registered")
 	return ctx
@@ -261,4 +262,8 @@ func (p *Wallet) IssueNewAsset(ctx context.Context, changeAddress string, spendI
 
 func (p *Wallet) ReissueAsset(ctx context.Context, changeAddress string, request common.ReissuanceRequest) (common.ReissuanceResponse, error) {
 	return chain.ReissueAsset(ctx, changeAddress, request)
+}
+
+func (p *Wallet) BurnAsset(ctx context.Context, destAddress, changeAddress string, request common.BurnRequest) (common.BurnResponse, error) {
+	return chain.BurnAsset(ctx, destAddress, changeAddress, request)
 }

--- a/wallet.go
+++ b/wallet.go
@@ -134,6 +134,7 @@ func (p *Wallet) registerHandlers(ctx context.Context) context.Context {
 
 	nats.SubscribeWorkers(ctx, common.WalletStatusSubject, concurencyLevel, handlers.OnWalletStatus)
 	nats.SubscribeWorkers(ctx, common.WalletListSubject, concurencyLevel, handlers.OnWalletList)
+	nats.SubscribeWorkers(ctx, common.AssetListIssuancesSubject, concurencyLevel, handlers.OnListIssuances)
 	nats.SubscribeWorkers(ctx, common.AssetIssuanceSubject, concurencyLevel, handlers.OnAssetIssuance)
 
 	log.Debug("Bank Wallet registered")
@@ -247,6 +248,10 @@ func (p *Wallet) GetAddressInfo(ctx context.Context, chainName, address string) 
 
 func (p *Wallet) WalletInfo(ctx context.Context, chainName string) (common.WalletInfo, error) {
 	return chain.WalletInfo(ctx, chainName)
+}
+
+func (p *Wallet) ListIssuances(ctx context.Context, request common.ListIssuancesRequest) ([]common.IssuanceInfo, error) {
+	return chain.ListIssuances(ctx, request)
 }
 
 func (p *Wallet) IssueNewAsset(ctx context.Context, changeAddress string, spendInfos common.SpendInfo, request common.IssuanceRequest) (common.IssuanceResponse, error) {

--- a/wallet.go
+++ b/wallet.go
@@ -136,6 +136,7 @@ func (p *Wallet) registerHandlers(ctx context.Context) context.Context {
 	nats.SubscribeWorkers(ctx, common.WalletListSubject, concurencyLevel, handlers.OnWalletList)
 	nats.SubscribeWorkers(ctx, common.AssetListIssuancesSubject, concurencyLevel, handlers.OnListIssuances)
 	nats.SubscribeWorkers(ctx, common.AssetIssuanceSubject, concurencyLevel, handlers.OnAssetIssuance)
+	nats.SubscribeWorkers(ctx, common.AssetReissuanceSubject, concurencyLevel, handlers.OnAssetReissuance)
 
 	log.Debug("Bank Wallet registered")
 	return ctx
@@ -256,4 +257,8 @@ func (p *Wallet) ListIssuances(ctx context.Context, request common.ListIssuances
 
 func (p *Wallet) IssueNewAsset(ctx context.Context, changeAddress string, spendInfos common.SpendInfo, request common.IssuanceRequest) (common.IssuanceResponse, error) {
 	return chain.IssueNewAsset(ctx, changeAddress, spendInfos, request)
+}
+
+func (p *Wallet) ReissueAsset(ctx context.Context, changeAddress string, request common.ReissuanceRequest) (common.ReissuanceResponse, error) {
+	return chain.ReissueAsset(ctx, changeAddress, request)
 }


### PR DESCRIPTION
- Add support for elements RPC commands `rawissueasset`, `rawreissueasset` and `listissuances`
- Implements internal API to list, issue, reissue and burn assets